### PR TITLE
Remove bower instructions from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,9 +37,6 @@ Then, before your closing ```<body>``` tag add:
 #### Package Managers
 
 ```sh
-# Bower
-bower install --save slick-carousel
-
 # NPM
 npm install slick-carousel
 ```


### PR DESCRIPTION
## Summary
- delete Bower install directions from Package Managers section

## Testing
- `git show -U2`


------
https://chatgpt.com/codex/tasks/task_e_686db19af7dc832389e55726228152c8